### PR TITLE
Add lfm-physics to Quantum Physics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Please take a quick look at the [contribution guidelines](./CONTRIBUTING.md) fir
 * [artiq](https://github.com/m-labs/artiq) - Next-generation control system for quantum information experiments
 * [flavio](https://github.com/flav-io/flavio) - flavour phenomenology in the Standard model and beyond
 * [hepdata](https://github.com/HEPData/hepdata) - the high energy physics data repository
+* [lfm-physics](https://github.com/gpartin/lfm-physics) - Lattice Field Medium simulation library with GPU acceleration, deriving gravity, EM, and quantum phenomena from two coupled wave equations
 * [particle-clicker](https://github.com/particle-clicker/particle-clicker) - An addictive incremental game that teaches players the history of high energy particle physics
 * [Psi4](https://github.com/psi4/psi4) - Open-source Quantum Chemistry
 * [pypdt](https://bitbucket.org/andybuckley/pypdt) - Pythonic access to high energy particle data tables and ID codes

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Please take a quick look at the [contribution guidelines](./CONTRIBUTING.md) fir
 * [artiq](https://github.com/m-labs/artiq) - Next-generation control system for quantum information experiments
 * [flavio](https://github.com/flav-io/flavio) - flavour phenomenology in the Standard model and beyond
 * [hepdata](https://github.com/HEPData/hepdata) - the high energy physics data repository
-* [lfm-physics](https://github.com/gpartin/lfm-physics) - Lattice Field Medium simulation library with GPU acceleration, deriving gravity, EM, and quantum phenomena from two coupled wave equations
+* [lfm-physics](https://github.com/gpartin/lfm-physics) - Lattice Field Medium simulation library with GPU acceleration, deriving gravity, electromagnetism, and quantum phenomena from two coupled wave equations
 * [particle-clicker](https://github.com/particle-clicker/particle-clicker) - An addictive incremental game that teaches players the history of high energy particle physics
 * [Psi4](https://github.com/psi4/psi4) - Open-source Quantum Chemistry
 * [pypdt](https://bitbucket.org/andybuckley/pypdt) - Pythonic access to high energy particle data tables and ID codes


### PR DESCRIPTION
Adds [lfm-physics](https://github.com/gpartin/lfm-physics) — a Lattice Field Medium simulation library that derives gravity, electromagnetism, and quantum phenomena from two coupled wave equations on a discrete lattice.

- **PyPI**: https://pypi.org/project/lfm-physics/
- **License**: MIT
- **Python**: 3.10+
- **Tests**: 233 passing
- **Key features**: GPU-accelerated lattice solvers (CuPy/Numba), 41+ verified physics predictions, cosmological simulation tools